### PR TITLE
[TRI-416] Fix associate jira with slack mention by email

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,6 @@ config.ini.sample
 # JIRA username / password
 username = JIRA username
 password = JIRA password
-# Slack webhook
-webhook_url = Slack webhook URL
 # Slack API token
 token = Slack API token
 # debug mode(True or False)

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ username = JIRA username
 password = JIRA password
 # Slack webhook
 webhook_url = Slack webhook URL
+# Slack API token
+token = Slack API token
 # debug mode(True or False)
 debug = False
 ```

--- a/config.ini.sample
+++ b/config.ini.sample
@@ -4,7 +4,7 @@ username = JIRA username
 password = JIRA password
 # Slack webhook
 webhook_url = Slack webhook URL
-# Slack token
-token = Slack token
+# Slack API token
+token = Slack API token
 # debug mode(True or False)
 debug = False

--- a/config.ini.sample
+++ b/config.ini.sample
@@ -2,8 +2,6 @@
 # JIRA username / password
 username = JIRA username
 password = JIRA password
-# Slack webhook
-webhook_url = Slack webhook URL
 # Slack API token
 token = Slack API token
 # debug mode(True or False)

--- a/config.ini.sample
+++ b/config.ini.sample
@@ -4,5 +4,7 @@ username = JIRA username
 password = JIRA password
 # Slack webhook
 webhook_url = Slack webhook URL
+# Slack token
+token = Slack token
 # debug mode(True or False)
 debug = False

--- a/issue.py
+++ b/issue.py
@@ -178,7 +178,7 @@ def send_message_to_slack(title, text, channel, token, debug):
     """
     メッセージを Slack に送信
     """
-    print(text)
+
     url = SLACK_API + 'chat.postMessage'
     payload = {
         'token': token,

--- a/issue.py
+++ b/issue.py
@@ -54,7 +54,7 @@ FACES = ('┗┫￣皿￣┣┛', '┗┃￣□￣；┃┓ ',
          '┗┫＝皿[＋]┣┛')
 
 
-def issue_to_dict(jira, issue, users):
+def issue_to_dict(issue, users):
     """
     issue から必要な値を取り出して、いい感じの辞書にして返す
     """
@@ -100,7 +100,7 @@ def get_issues(jira, query, users):
     """
     issues = []
     for issue in jira.search_issues(query):
-        issues.append(issue_to_dict(jira, issue, users))
+        issues.append(issue_to_dict(issue, users))
 
     return issues
 


### PR DESCRIPTION
https://pyconjp.atlassian.net/browse/TRI-416

Associate JIRA user with Slack mention by email on report.
It has become necessary Slack API token by this fix.

* [ ] Success load Use list from Slack API
    * [ ] Add Slack token to config.ini