### PR TITLE
slackに流れる使用方法を修正するPR

### DIFF
--- a/issue.py
+++ b/issue.py
@@ -166,7 +166,7 @@ def create_issue_message(title, issues):
     """
     # 通知用のテキストを生成
     text = '{}ハ *{}件* デス{}\n'.format(title, len(issues), random.choice(FACES))
-    text += '> JIRAの氏名https://id.atlassian.com/manage-profile とSlackのFull nameを同一にするとここでメンションされるのでおすすめ(大文字小文字は無視) '
+    text += '> JIRAの氏名https://id.atlassian.com/manage-profile とSlackのFull nameを同一にするとここでメンションされるのでおすすめ(大文字小文字は無視)\n'
     for issue in issues:
         text += formatted_issue(issue) + '\n'
 

--- a/issue.py
+++ b/issue.py
@@ -166,7 +166,7 @@ def create_issue_message(title, issues):
     """
     # 通知用のテキストを生成
     text = '{}ハ *{}件* デス{}\n'.format(title, len(issues), random.choice(FACES))
-    text += '> JIRAのユーザー名とSlackのSlackのFull nameを同一にするとメンションされます(大文字小文字は無視)\n'
+    text += '> JIRAの氏名https://id.atlassian.com/manage-profile とSlackのFull nameを同一にするとここでメンションされるのでおすすめ(大文字小文字は無視) '
     for issue in issues:
         text += formatted_issue(issue) + '\n'
 

--- a/issue.py
+++ b/issue.py
@@ -166,7 +166,7 @@ def create_issue_message(title, issues):
     """
     # 通知用のテキストを生成
     text = '{}ハ *{}件* デス{}\n'.format(title, len(issues), random.choice(FACES))
-    text += '> JIRAの氏名https://id.atlassian.com/manage-profile とSlackのFull nameを同一にするとここでメンションされるのでおすすめ(大文字小文字は無視)\n'
+    text += '> JIRAの氏名(https://id.atlassian.com/manage-profile)とSlackのFull nameを同一にするとメンションされるのでおすすめ(大文字小文字は無視)\n'
     for issue in issues:
         text += formatted_issue(issue) + '\n'
 


### PR DESCRIPTION
JIRAの日本語UIの場合、判定対象は下記で設定できる[氏名]が正解でした。
変更できるURIもわかりにくいとこにある
https://id.atlassian.com/manage-profile/profile-and-visibility
https://id.atlassian.com/manage-profile が現状リダイレクトされて短いので使用
UIが英語の場合は[Full name]の認識